### PR TITLE
Re-implement Seed Snatcher dive movement & conditions for dive

### DIFF
--- a/Assets/Prefabs/Seed Snatcher/SeedSnatcher.prefab
+++ b/Assets/Prefabs/Seed Snatcher/SeedSnatcher.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 5938091071472260474}
   - component: {fileID: 2752951619462235140}
   - component: {fileID: -7815057116725434919}
+  - component: {fileID: 5003312102553885741}
   m_Layer: 0
   m_Name: SeedSnatcher
   m_TagString: Untagged
@@ -133,7 +134,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1b3215236a1d4351832caa8f69de3a48, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 2
+  speed: 5
   positionTolerance: 0.5
   sprite: {fileID: -292803467, guid: eec170aa53acaf0f3af9adeb690d070d, type: 3}
 --- !u!114 &2752951619462235140
@@ -150,6 +151,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 0}
   doFindTarget: 1
+  maximumRange: 100
 --- !u!95 &-7815057116725434919
 Animator:
   serializedVersion: 7
@@ -172,3 +174,20 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &5003312102553885741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6130611759229974114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7cc449f987634be98e1b2e8457c232fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 3
+  positionTolerance: 0.5
+  sprite: {fileID: 0}
+  maximumDiveRange: 20
+  minimumDiveHeight: 10

--- a/Assets/Prefabs/Seed Snatcher/SeedSnatcher.prefab
+++ b/Assets/Prefabs/Seed Snatcher/SeedSnatcher.prefab
@@ -12,10 +12,10 @@ GameObject:
   - component: {fileID: 4016279904239132408}
   - component: {fileID: 3999221644882844016}
   - component: {fileID: 7183048973495059240}
+  - component: {fileID: 5003312102553885741}
   - component: {fileID: 5938091071472260474}
   - component: {fileID: 2752951619462235140}
   - component: {fileID: -7815057116725434919}
-  - component: {fileID: 5003312102553885741}
   m_Layer: 0
   m_Name: SeedSnatcher
   m_TagString: Untagged
@@ -122,6 +122,23 @@ MonoBehaviour:
   sprite: {fileID: -292803467, guid: eec170aa53acaf0f3af9adeb690d070d, type: 3}
   patrolStartPosition: {x: 0, y: 0, z: 0}
   patrolEndPosition: {x: 0, y: 0, z: 0}
+--- !u!114 &5003312102553885741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6130611759229974114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7cc449f987634be98e1b2e8457c232fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 3
+  positionTolerance: 0.5
+  sprite: {fileID: 736463740, guid: eec170aa53acaf0f3af9adeb690d070d, type: 3}
+  maximumDiveRange: 20
+  minimumDiveHeight: 10
 --- !u!114 &5938091071472260474
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -134,9 +151,67 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1b3215236a1d4351832caa8f69de3a48, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 5
+  speed: 3
   positionTolerance: 0.5
   sprite: {fileID: -292803467, guid: eec170aa53acaf0f3af9adeb690d070d, type: 3}
+  diveCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  recoveryCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.47539157
+      value: 0.48690963
+      inSlope: 0.35755014
+      outSlope: 0.35755014
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 1.9245291
+      outSlope: 1.9245291
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.20853743
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  diveDuration: 1
 --- !u!114 &2752951619462235140
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -174,20 +249,3 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &5003312102553885741
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6130611759229974114}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7cc449f987634be98e1b2e8457c232fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  speed: 3
-  positionTolerance: 0.5
-  sprite: {fileID: 0}
-  maximumDiveRange: 20
-  minimumDiveHeight: 10

--- a/Assets/Prefabs/Seed Snatcher/SeedSnatcher.prefab
+++ b/Assets/Prefabs/Seed Snatcher/SeedSnatcher.prefab
@@ -184,29 +184,20 @@ MonoBehaviour:
     - serializedVersion: 3
       time: 0
       value: 0
-      inSlope: 2
-      outSlope: 2
-      tangentMode: 0
+      inSlope: 1
+      outSlope: 1
+      tangentMode: 34
       weightedMode: 0
       inWeight: 0
       outWeight: 0
     - serializedVersion: 3
-      time: 0.47539157
-      value: 0.48690963
-      inSlope: 0.35755014
-      outSlope: 0.35755014
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
       time: 1
       value: 1
-      inSlope: 1.9245291
-      outSlope: 1.9245291
-      tangentMode: 0
+      inSlope: 1
+      outSlope: 1
+      tangentMode: 34
       weightedMode: 0
-      inWeight: 0.20853743
+      inWeight: 0
       outWeight: 0
     m_PreInfinity: 2
     m_PostInfinity: 2

--- a/Assets/Scenes/MemberWorkspaces/Ganyuke.unity
+++ b/Assets/Scenes/MemberWorkspaces/Ganyuke.unity
@@ -193,7 +193,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  expiryTime: 10
+  expiryTime: 1
   canExpire: 1
   isExpired: 0
   isBeingTargeted: 0
@@ -261,7 +261,7 @@ Transform:
   m_GameObject: {fileID: 650682639}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.28, y: -0.22, z: 0}
+  m_LocalPosition: {x: -7.03, y: -0.94, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -367,8 +367,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  expiryTime: 10
-  canExpire: 1
+  expiryTime: 1
+  canExpire: 0
   isExpired: 0
   isBeingTargeted: 0
 --- !u!1 &868757549
@@ -401,7 +401,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  expiryTime: 10
+  expiryTime: 1
   canExpire: 1
   isExpired: 0
   isBeingTargeted: 0
@@ -475,6 +475,110 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &930398812
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 930398815}
+  - component: {fileID: 930398814}
+  - component: {fileID: 930398813}
+  m_Layer: 0
+  m_Name: SeedExample (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &930398813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 930398812}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  expiryTime: 1
+  canExpire: 1
+  isExpired: 0
+  isBeingTargeted: 0
+--- !u!212 &930398814
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 930398812}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.9339623, g: 0.6909722, b: 0.15419187, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &930398815
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 930398812}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: -0.33996922, w: 0.9404366}
+  m_LocalPosition: {x: 8.43, y: -3.72, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -39.75}
 --- !u!1001 &989596172
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -709,6 +813,214 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!1 &1066288325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1066288328}
+  - component: {fileID: 1066288327}
+  - component: {fileID: 1066288326}
+  m_Layer: 0
+  m_Name: SeedExample (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1066288326
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066288325}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  expiryTime: 1
+  canExpire: 1
+  isExpired: 0
+  isBeingTargeted: 0
+--- !u!212 &1066288327
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066288325}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.9339623, g: 0.6909722, b: 0.15419187, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1066288328
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066288325}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.6, y: -3.58, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1128299583
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1128299586}
+  - component: {fileID: 1128299585}
+  - component: {fileID: 1128299584}
+  m_Layer: 0
+  m_Name: SeedExample (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1128299584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1128299583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  expiryTime: 1
+  canExpire: 1
+  isExpired: 0
+  isBeingTargeted: 0
+--- !u!212 &1128299585
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1128299583}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.9339623, g: 0.6909722, b: 0.15419187, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1128299586
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1128299583}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -7.03, y: 4.58, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1196986664
 GameObject:
   m_ObjectHideFlags: 0
@@ -739,7 +1051,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  expiryTime: 10
+  expiryTime: 1
   canExpire: 1
   isExpired: 0
   isBeingTargeted: 0
@@ -813,6 +1125,214 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1219608375
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1219608378}
+  - component: {fileID: 1219608377}
+  - component: {fileID: 1219608376}
+  m_Layer: 0
+  m_Name: SeedExample (11)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1219608376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1219608375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  expiryTime: 1
+  canExpire: 1
+  isExpired: 0
+  isBeingTargeted: 0
+--- !u!212 &1219608377
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1219608375}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.9339623, g: 0.6909722, b: 0.15419187, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1219608378
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1219608375}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.69, y: 1.32, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1403869928
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1403869931}
+  - component: {fileID: 1403869930}
+  - component: {fileID: 1403869929}
+  m_Layer: 0
+  m_Name: SeedExample (12)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1403869929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1403869928}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  expiryTime: 1
+  canExpire: 1
+  isExpired: 0
+  isBeingTargeted: 0
+--- !u!212 &1403869930
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1403869928}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.9339623, g: 0.6909722, b: 0.15419187, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1403869931
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1403869928}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.020468095, y: -0.045121662, z: 0.41259712, w: 0.90956515}
+  m_LocalPosition: {x: 5.77, y: -4.18, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -5.68, z: 48.8}
 --- !u!1 &1485755312
 GameObject:
   m_ObjectHideFlags: 0
@@ -843,7 +1363,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  expiryTime: 10
+  expiryTime: 1
   canExpire: 1
   isExpired: 0
   isBeingTargeted: 0
@@ -912,6 +1432,318 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2.85, y: -1.07, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1571466011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1571466014}
+  - component: {fileID: 1571466013}
+  - component: {fileID: 1571466012}
+  m_Layer: 0
+  m_Name: SeedExample (10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1571466012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1571466011}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  expiryTime: 1
+  canExpire: 1
+  isExpired: 0
+  isBeingTargeted: 0
+--- !u!212 &1571466013
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1571466011}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.9339623, g: 0.6909722, b: 0.15419187, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1571466014
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1571466011}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.21, y: 3.61, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1997922569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1997922572}
+  - component: {fileID: 1997922571}
+  - component: {fileID: 1997922570}
+  m_Layer: 0
+  m_Name: SeedExample (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1997922570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997922569}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  expiryTime: 1
+  canExpire: 1
+  isExpired: 0
+  isBeingTargeted: 0
+--- !u!212 &1997922571
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997922569}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.9339623, g: 0.6909722, b: 0.15419187, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1997922572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1997922569}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0.1773424, w: 0.9841492}
+  m_LocalPosition: {x: 0.73, y: -4.15, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 20.43}
+--- !u!1 &2055406757
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2055406760}
+  - component: {fileID: 2055406759}
+  - component: {fileID: 2055406758}
+  m_Layer: 0
+  m_Name: SeedExample (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2055406758
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2055406757}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 099c3c1f89ae4f13b6cd8d7dbb3f0543, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  expiryTime: 1
+  canExpire: 1
+  isExpired: 0
+  isBeingTargeted: 0
+--- !u!212 &2055406759
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2055406757}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.9339623, g: 0.6909722, b: 0.15419187, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &2055406760
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2055406757}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.34, y: 0.06, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1020,6 +1852,14 @@ SceneRoots:
   - {fileID: 1485755315}
   - {fileID: 868757552}
   - {fileID: 650682642}
+  - {fileID: 1997922572}
+  - {fileID: 930398815}
+  - {fileID: 1066288328}
+  - {fileID: 2055406760}
+  - {fileID: 1128299586}
+  - {fileID: 1571466014}
+  - {fileID: 1219608378}
+  - {fileID: 1403869931}
   - {fileID: 4510336084750765168}
   - {fileID: 989596172}
   - {fileID: 59314372}

--- a/Assets/Scenes/MemberWorkspaces/Ganyuke.unity
+++ b/Assets/Scenes/MemberWorkspaces/Ganyuke.unity
@@ -592,8 +592,28 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
-      propertyPath: speed
-      value: 1
+      propertyPath: animeCurve.m_Curve.Array.data[0].inSlope
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: animeCurve.m_Curve.Array.data[1].inSlope
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: animeCurve.m_Curve.Array.data[0].outSlope
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: animeCurve.m_Curve.Array.data[1].outSlope
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: animeCurve.m_Curve.Array.data[0].tangentMode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: animeCurve.m_Curve.Array.data[1].tangentMode
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6130611759229974114, guid: 7c682af96484c400e8de281add319675, type: 3}
       propertyPath: m_Name
@@ -1759,6 +1779,42 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4016279904239132408, guid: 7c682af96484c400e8de281add319675, type: 3}
       propertyPath: m_FlipX
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: recoveryCurve.m_Curve.Array.data[1].time
+      value: 0.9791565
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: recoveryCurve.m_Curve.Array.data[0].value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: recoveryCurve.m_Curve.Array.data[1].value
+      value: 0.9268875
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: recoveryCurve.m_Curve.Array.data[0].inSlope
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: recoveryCurve.m_Curve.Array.data[1].inSlope
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: recoveryCurve.m_Curve.Array.data[0].outSlope
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: recoveryCurve.m_Curve.Array.data[1].outSlope
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: recoveryCurve.m_Curve.Array.data[0].tangentMode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938091071472260474, guid: 7c682af96484c400e8de281add319675, type: 3}
+      propertyPath: recoveryCurve.m_Curve.Array.data[1].tangentMode
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6130611759229974114, guid: 7c682af96484c400e8de281add319675, type: 3}

--- a/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherDive.cs
+++ b/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherDive.cs
@@ -102,6 +102,7 @@ namespace SeedSnatcher.Behavior.Movement
 
         private void ExitDive()
         {
+            transform.rotation = Quaternion.Euler(0.0f, 0.0f, 0.0f);
             GetSnatcherController().SetState(SnatcherState.Idle);
         }
 
@@ -124,6 +125,7 @@ namespace SeedSnatcher.Behavior.Movement
             if (diveStage < 1 && !GetSnatcherTargeting().HasTarget())
             {
                 ExitDive();
+                return;
             }
             
             // Setup for dive stages
@@ -168,13 +170,9 @@ namespace SeedSnatcher.Behavior.Movement
                 }
             }
             // Orient bird to next point
-            // float xComp = nextPosition.x - StartPosition.x;
-            // float yComp = nextPosition.y - StartPosition.y;
-            // float angle = Mathf.Atan2(yComp, xComp) * Mathf.Rad2Deg;
             Vector2 target = nextPosition - StartPosition;
             float angle = Vector2.SignedAngle(IsFacingLeft() ? Vector2.left : Vector2.right, target);
             transform.rotation = Quaternion.Euler(0.0f, 0.0f, angle);
-            
             
             // Move to next stage when end of curve reached
             if (diveStep < path.Count) return;

--- a/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherDive.cs
+++ b/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherDive.cs
@@ -99,6 +99,14 @@ namespace SeedSnatcher.Behavior.Movement
         private DiveStage diveStage;
         private BezierPathing bezierPathing;
 
+        [SerializeField] private AnimationCurve diveCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
+        [SerializeField] private AnimationCurve recoveryCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
+        [SerializeField] private float recoveryDistance = 10.0f;
+        private float diveDuration = 5f;
+        private float elapsedTime;
+        private Vector3 targetPosition;
+        private AnimationCurve animeCurve;
+
         private void ExitDive()
         {
             transform.rotation = Quaternion.Euler(0.0f, 0.0f, 0.0f);
@@ -113,13 +121,6 @@ namespace SeedSnatcher.Behavior.Movement
             diveStage = 0;
             isNewStage = true;
         }
-
-        public AnimationCurve diveCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
-        public AnimationCurve recoveryCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
-        public float diveDuration = 5f;
-        private float elapsedTime;
-        private Vector3 targetPosition;
-        private AnimationCurve animeCurve;
         
         public override void Loop()
         {
@@ -143,10 +144,12 @@ namespace SeedSnatcher.Behavior.Movement
                         break;
                     case DiveStage.Recovery:
                         GetSnatcherTargeting().DestroyTarget();
-                        var newEndPosition = StartPosition;
+                        var originalHeight = StartPosition.y;
                         StartPosition = EndPosition;
-                        newEndPosition.x = 2 * (2 * EndPosition.x - newEndPosition.x);
-                        EndPosition = newEndPosition;
+                        var recoveryDirection = IsFacingLeft() ? Vector3.left : Vector3.right;
+                        var recoveryXComp = recoveryDirection * recoveryDistance;
+                        EndPosition = StartPosition + recoveryXComp;
+                        EndPosition.y = originalHeight;
                         animeCurve = recoveryCurve;
                         bezierPathing = new BezierPathing(StartPosition, EndPosition, animeCurve);
                         break;

--- a/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherDive.cs
+++ b/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherDive.cs
@@ -4,14 +4,84 @@ using UnityEngine;
 
 namespace SeedSnatcher.Behavior.Movement
 {
+    internal class BezierPathing
+    {
+        private readonly List<Vector3> controlPoints;
+        private readonly AnimationCurve animeCurve;
+        public float Length { get; }
+
+        public BezierPathing(List<Vector3> controlPoints, AnimationCurve animeCurve)
+        {
+            this.animeCurve = animeCurve;
+            this.controlPoints = controlPoints;
+            Length = CalculateLength();
+        }
+        
+        public BezierPathing(Vector3 startPosition, Vector3 endPosition, AnimationCurve animeCurve)
+        {
+            this.animeCurve = animeCurve;
+            controlPoints = SetupControlPoints(startPosition, endPosition);
+            Length = CalculateLength();
+        }
+        
+        /**
+         * Computes appropriate control points for the
+         * dive's Bézier curve.
+         */
+        private List<Vector3> SetupControlPoints(Vector3 startPosition, Vector3 endPosition)
+        {
+            var midpointTop = (startPosition + endPosition) / 2;
+            midpointTop.y = startPosition.y;
+            var midpointBottom = midpointTop;
+            midpointBottom.y = endPosition.y;
+            /*var midpointMidpoint = (midpointBottom + midpointTop) / 2;
+            var startLow = new Vector3(startPosition.x, endPosition.y, 0.0f);
+            var midpoint = (startPosition + endPosition) / 2;
+            var midpointHigh = new Vector3(midpoint.x, startPosition.y, 0.0f);
+            var midpointLow = new Vector3(midpoint.x, endPosition.y, 0.0f);*/
+            
+            return new List<Vector3>()
+            {
+                startPosition,
+                midpointTop,
+                midpointBottom,
+                endPosition
+            };
+        }
+        
+        public Vector3 CalculateNextPosition(float normalizedTime)
+        {
+            var t = animeCurve.Evaluate(normalizedTime);
+            return BezierCurve.CalculateBezierPoint(controlPoints, t);
+        }
+        
+        private float CalculateLength(int precision = 100)
+        {
+            var length = 0f;
+            var prev = controlPoints[0];
+            for (var i = 0; i < precision; i++)
+            {
+                var percentage = i / (precision * 1.0f);
+                var targetPosition = CalculateNextPosition(percentage);
+                var distance = Vector3.Distance(prev, targetPosition);
+                length += distance;
+                Debug.DrawLine(targetPosition, prev, Color.red, 90);
+                prev = targetPosition;
+            }
+
+            return length;
+        }
+    }
+    
+    internal enum DiveStage {
+        Dive,
+        Recovery,
+        Glide,
+        Complete
+    }
+    
     public class SnatcherDive : SnatcherMovement
     {
-        /** for creating the Bézier curve */
-        private List<Vector3> controlPoints;
-        /** the actual points along the curve */
-        private List<Vector3> path;
-        /** the position in the dive */
-        private int diveStep;
         /**
          * Whether a stage has just changed.
          * Can't use diveStep == 0 since we can't be sure
@@ -19,8 +89,6 @@ namespace SeedSnatcher.Behavior.Movement
          */
         private bool isNewStage = true;
 
-        private float acceleratedSpeed;
-        
         /**
          * Dives have three stages: start, bottom, and end.
          * The start stage creates the curve down to the bottom
@@ -28,77 +96,8 @@ namespace SeedSnatcher.Behavior.Movement
          * end position (on top of handling the target). The end
          * stage switches back to the idle mode.
          */
-        private int diveStage;
-
-        /**
-         * Computes appropriate control points for the
-         * dive's Bézier curve.
-         */
-        private void SetupControlPoints()
-        {
-            var midpointTop = (StartPosition + EndPosition) / 2;
-            midpointTop.y = StartPosition.y;
-            var midpointBottom = midpointTop;
-            midpointBottom.y = EndPosition.y;
-            var midpointMidpoint = (midpointBottom + midpointTop) / 2;
-
-            controlPoints = new List<Vector3>()
-            {
-                StartPosition,
-                midpointTop,
-                midpointMidpoint,
-                midpointBottom,
-                EndPosition
-            };
-        }
-        
-        /**
-         * Generates a Bézier curve that the bird should fly along,
-         * using `controlPoints` for De Casteljau's algorithm.
-         */
-        private void GeneratePath(int precision = 100)
-        {
-            path = new List<Vector3>();
-            for (var i = 0; i < precision; i++)
-            {
-                var percentage = i / (precision * 1.0f);
-                var targetPosition = BezierCurve.CalculateBezierPoint(controlPoints, percentage);
-                path.Add(targetPosition);
-                if (path.Count > 1)
-                {
-                    Debug.DrawLine(path[i], path[i - 1], Color.red, 90);
-                }
-            }
-        }
-        
-        /**
-         * Generates the curve back up from the bottom.
-         * The end point will be the same Y position as
-         * the original start point. Its X position will
-         * be the distance from the original target position,
-         * times two.
-         */
-        private void CalculateReverseDive()
-        {
-            var newEndPosition = StartPosition;
-            StartPosition = EndPosition;
-            newEndPosition.x = 2 * EndPosition.x - newEndPosition.x;
-            EndPosition = newEndPosition;
-        }
-
-        /**
-         * Wrapper function for all the helper
-         * functions to set up the curve.
-         *
-         * Kinda useless. Maybe I should just
-         * make the actual functions do more.
-         */
-        private void SetupDive()
-        {
-            SetupControlPoints();
-            GeneratePath();
-            DetermineFacingDirection();
-        }
+        private DiveStage diveStage;
+        private BezierPathing bezierPathing;
 
         private void ExitDive()
         {
@@ -112,73 +111,87 @@ namespace SeedSnatcher.Behavior.Movement
             SetSprite();
             // reset values to defaults in case this was previously used
             diveStage = 0;
-            diveStep = 0;
-            controlPoints = null;
-            path = null;
             isNewStage = true;
-            acceleratedSpeed = speed;
         }
 
+        public AnimationCurve diveCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
+        public AnimationCurve recoveryCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
+        public float diveDuration = 5f;
+        private float elapsedTime;
+        private Vector3 targetPosition;
+        private AnimationCurve animeCurve;
+        
         public override void Loop()
         {
             // Cancel when the target disappears (i.e. seed picked up)
-            if (diveStage < 1 && !GetSnatcherTargeting().HasTarget())
+            if ((int)diveStage < 1 && !GetSnatcherTargeting().HasTarget())
             {
                 ExitDive();
                 return;
             }
-            
-            // Setup for dive stages
+
             if (isNewStage)
             {
-                isNewStage = false;
                 switch (diveStage)
                 {
-                    case 0:
+                    case DiveStage.Dive:
                         var thisPosition = transform.position;
-                        var targetPosition = GetSnatcherTargeting().GetTargetPosition();
+                        targetPosition = GetSnatcherTargeting().GetTargetPosition();
                         (StartPosition, EndPosition) = (thisPosition, targetPosition);
-                        SetupDive();
-                        Debug.DrawLine(StartPosition, EndPosition, Color.green, 90);
+                        animeCurve = diveCurve;
+                        bezierPathing = new BezierPathing(StartPosition, EndPosition, animeCurve);
                         break;
-                    case 1:
+                    case DiveStage.Recovery:
                         GetSnatcherTargeting().DestroyTarget();
-                        CalculateReverseDive();
-                        SetupDive();
+                        var newEndPosition = StartPosition;
+                        StartPosition = EndPosition;
+                        newEndPosition.x = 2 * (2 * EndPosition.x - newEndPosition.x);
+                        EndPosition = newEndPosition;
+                        animeCurve = recoveryCurve;
+                        bezierPathing = new BezierPathing(StartPosition, EndPosition, animeCurve);
                         break;
-                    case 2:
+                    case DiveStage.Glide:
+                        /*StartPosition = EndPosition;
+                        EndPosition.x *= 1.1f;
+                        var ctrlPts = new List<Vector3>()
+                        {
+                            StartPosition,
+                            EndPosition
+                        };
+                        animeCurve = AnimationCurve.Linear(0, 0, 1, 1);
+                        bezierPathing = new BezierPathing(ctrlPts, animeCurve);
+                        break;*/
+                    case DiveStage.Complete:
+                    default:
                         ExitDive();
-                        break;
+                        return;
                 }
+                
+                DetermineFacingDirection();
+                diveDuration = bezierPathing.Length / speed;
+                isNewStage = false;
             }
-
-            if (path == null) return;
             
-            // Move to next point in curve
-            var nextPosition = path[diveStep];
-            transform.position = Vector3.MoveTowards(transform.position, nextPosition, acceleratedSpeed * Time.deltaTime);
-            if (HasReachedPosition(nextPosition))
-            {
-                diveStep++;
-                if (diveStage < 1)
-                {
-                    acceleratedSpeed = Mathf.Max(speed, 5.0f * (diveStep + 1) / path.Count + 0.2f);
-                }
-                else
-                {
-                    acceleratedSpeed = Mathf.Max(speed, 5.0f * (path.Count - diveStep) / path.Count + 0.2f);
-                }
-            }
+            elapsedTime += Time.deltaTime;
+            var normalizedTime = elapsedTime / diveDuration;
+            var pos = bezierPathing.CalculateNextPosition(normalizedTime);
+            
+            transform.position = pos;
+            
+            var lookAheadTime = Mathf.Max(elapsedTime + 0.3f, 1f);
+            var lookAheadPos = bezierPathing.CalculateNextPosition(lookAheadTime);
+            
             // Orient bird to next point
-            Vector2 target = nextPosition - StartPosition;
+            Vector2 target = lookAheadPos - pos;
             float angle = Vector2.SignedAngle(IsFacingLeft() ? Vector2.left : Vector2.right, target);
             transform.rotation = Quaternion.Euler(0.0f, 0.0f, angle);
-            
-            // Move to next stage when end of curve reached
-            if (diveStep < path.Count) return;
-            diveStep = 0;
-            diveStage++;
-            isNewStage = true;
+
+            if (elapsedTime >= diveDuration || (diveStage == DiveStage.Recovery && (lookAheadPos - pos).magnitude < 0.5f))
+            {
+                diveStage += 1;
+                isNewStage = true;
+                elapsedTime = 0;
+            }
         }
     }
 }

--- a/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherIdle.cs
+++ b/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherIdle.cs
@@ -46,7 +46,7 @@ namespace SeedSnatcher.Behavior.Movement
             snatcherTargeting.FindTarget();
             if (snatcherTargeting.HasTarget())
             {
-                GetSnatcherController().SetState(SnatcherState.Diving);
+                GetSnatcherController().SetState(SnatcherState.Investigate);
             }
         }
         

--- a/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherInvestigate.cs
+++ b/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherInvestigate.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+
+namespace SeedSnatcher.Behavior.Movement
+{
+    public class SnatcherInvestigate : SnatcherMovement
+    {
+        [SerializeField] private float maximumDiveRange;
+        [SerializeField] private float minimumDiveHeight;
+
+        private void PathToTarget()
+        {
+            var targetPosition = EndPosition;
+            if (targetPosition.y - StartPosition.y < minimumDiveHeight)
+            {
+                targetPosition.y += minimumDiveHeight;
+            }
+            else
+            {
+                targetPosition.y = StartPosition.y;
+            }
+            DetermineFacingDirection();
+            transform.position = Vector3.MoveTowards(StartPosition, targetPosition, speed * Time.deltaTime);
+        }
+        
+        public override void Init()
+        {
+            SetSprite();
+        }
+
+        public override void Loop()
+        {
+            StartPosition = transform.position;
+            if (GetSnatcherTargeting().HasTarget())
+            {
+                EndPosition = GetSnatcherTargeting().GetTargetPosition();
+                var isWithinRange = Vector3.Distance(StartPosition, EndPosition) < maximumDiveRange;
+                var isAtMinHeight = (StartPosition.y - (EndPosition.y + minimumDiveHeight)) <= positionTolerance;
+                if (isWithinRange && isAtMinHeight)
+                {
+                    GetSnatcherController().SetState(SnatcherState.Diving);
+                }
+                else
+                {
+                    PathToTarget();
+                }
+            }
+            else
+            {
+                GetSnatcherController().SetState(SnatcherState.Idle);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherInvestigate.cs.meta
+++ b/Assets/Scripts/SeedSnatcher/Behavior/Movement/SnatcherInvestigate.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7cc449f987634be98e1b2e8457c232fc
+timeCreated: 1745553005

--- a/Assets/Scripts/SeedSnatcher/Behavior/SnatcherTargeting.cs
+++ b/Assets/Scripts/SeedSnatcher/Behavior/SnatcherTargeting.cs
@@ -40,7 +40,12 @@ namespace SeedSnatcher.Behavior
 
         public bool HasTarget()
         {
-            return !target.IsUnityNull();
+            var isNull = target.IsUnityNull();
+            if (isNull)
+            {
+                target = null;
+            }
+            return !isNull;
         }
 
         public void DestroyTarget()

--- a/Assets/Scripts/SeedSnatcher/SnatcherController.cs
+++ b/Assets/Scripts/SeedSnatcher/SnatcherController.cs
@@ -7,7 +7,8 @@ namespace SeedSnatcher
     public enum SnatcherState
     {
         Idle,
-        Diving
+        Diving,
+        Investigate
     }
     
     public class SnatcherController : MonoBehaviour
@@ -26,7 +27,8 @@ namespace SeedSnatcher
             snatcherMovements = new Dictionary<SnatcherState, SnatcherMovement>()
             {
                 { SnatcherState.Idle, GetComponent<SnatcherIdle>()},
-                { SnatcherState.Diving, GetComponent<SnatcherDive>()}
+                { SnatcherState.Diving, GetComponent<SnatcherDive>()},
+                { SnatcherState.Investigate, GetComponent<SnatcherInvestigate>()}
             };
             
             SetState(SnatcherState.Idle);

--- a/Assets/Scripts/SeedSnatcher/Target/SnatchableTarget.cs
+++ b/Assets/Scripts/SeedSnatcher/Target/SnatchableTarget.cs
@@ -34,9 +34,13 @@ namespace SeedSnatcher.Target
             }
         }
 
-        public void Destroy()
+        public void OnDestroy()
         {
             seedManager.RemoveSeed(this);
+        }
+
+        public void Destroy()
+        {
             Destroy(gameObject);
         }
     }

--- a/Assets/Scripts/SeedSnatcher/Target/SnatcherTargetManager.cs
+++ b/Assets/Scripts/SeedSnatcher/Target/SnatcherTargetManager.cs
@@ -59,8 +59,16 @@ namespace SeedSnatcher.Target
             {
                 SnatchableTarget closestTarget = null;
                 var shortestDistance = float.MaxValue;
+                var badSeeds = new List<SnatchableTarget>();
                 foreach (var seed in expiredSeeds)
                 {
+                    // sometimes seeds may get destroyed for reasons beyond our control
+                    if (seed.IsUnityNull())
+                    {
+                        badSeeds.Add(seed);
+                        continue;
+                    }
+                    
                     if (seed.isBeingTargeted)
                     {
                         continue;
@@ -78,6 +86,11 @@ namespace SeedSnatcher.Target
                         closestTarget = seed;
                         shortestDistance = distance;
                     }
+                }
+
+                foreach (var seed in badSeeds)
+                {
+                    expiredSeeds.Remove(seed);
                 }
 
                 return closestTarget;


### PR DESCRIPTION
## Dive movement
Seed Snatcher dive now relies on a configurable `AnimationCurve` instead of increasing speed based on reaching points. The average speed at which it navigates the Bezier curve is configurable with the `speed` property. The simulated acceleration can be changed using the `AnimationCurve`.

## New state: `Investigate`
The Seed Snatcher now has a `Investigate` state upon detecting a seed in the `Idle` state. While in this state, it will path toward the targeted seed at a configurable speed (the prefab is currently set to be faster than the leisurely patrol seed). When within range, it will transition into the `Dive` state. If the seed is destroyed before it comes within range, it will break off, returning to the `Idle` state.